### PR TITLE
feat: add embed forwarding with link parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ telegram_forwarders:
     tg_channel_id: <tg channel id>
     discord_channel_id: <discord channel id>
     strip_off_links: False # whether to strip off links from the message
+    send_as_embed: False # whether to send messages as Discord embeds
     mention_everyone: True
     forward_everything: False # whether forwarding everything regardless the hashtag
     forward_hashtags:
@@ -136,6 +137,7 @@ telegram_forwarders:
     tg_channel_id: <tg channel id>
     discord_channel_id: <discord channel id>
     strip_off_links: False # whether to strip off links from the message
+    send_as_embed: False # whether to send messages as Discord embeds
     mention_everyone: False
     forward_everything: False # whether forwarding everything regardless the hashtag
     mention_override:

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -135,6 +135,7 @@ class ConfigRouter:
                     mention_everyone=forwarder["mention_everyone"],
                     forward_everything=forwarder["forward_everything"],
                     strip_off_links=forwarder["strip_off_links"],
+                    send_as_embed=forwarder["send_as_embed"],
                     forward_hashtags=(
                         forwarder["forward_hashtags"]
                         if forwarder["forward_hashtags"]

--- a/bridge/config/config.py
+++ b/bridge/config/config.py
@@ -22,6 +22,7 @@ class ForwarderConfig(BaseModel):
     tg_channel_id: StrictInt
     discord_channel_id: StrictInt
     strip_off_links: bool = False
+    send_as_embed: bool = False
     mention_everyone: bool = False
     forward_everything: bool = True
     forward_hashtags: Optional[List[dict]] = None

--- a/bridge/core.py
+++ b/bridge/core.py
@@ -1,9 +1,9 @@
 """A `bridge` to forward messages from Telegram to a Discord server."""
 
 import asyncio
-import copy
 import os
 import sys
+from types import SimpleNamespace
 from typing import List
 
 import discord
@@ -227,14 +227,16 @@ class Bridge:
             message_to_process = message
             if forwarder.send_as_embed:
                 cleaned_text, links = extract_urls(message)
-                message_to_process = copy.copy(message)
-                message_to_process.message = cleaned_text
+                message_entities = []
                 if message.entities:
-                    message_to_process.entities = [
+                    message_entities = [
                         entity
                         for entity in message.entities
                         if not isinstance(entity, MessageEntityUrl)
                     ]
+                message_to_process = SimpleNamespace(
+                    message=cleaned_text, entities=message_entities
+                )
 
             message_text = await self.process_message_text(
                 message_to_process,

--- a/bridge/core.py
+++ b/bridge/core.py
@@ -1,6 +1,7 @@
 """A `bridge` to forward messages from Telegram to a Discord server."""
 
 import asyncio
+import copy
 import os
 import sys
 from typing import List
@@ -13,7 +14,6 @@ from telethon.tl.types import (
     InputChannel,
     Message,
     MessageEntityHashtag,
-    MessageEntityTextUrl,
     MessageEntityUrl,
 )
 
@@ -22,7 +22,7 @@ from bridge.discord import DiscordHandler
 from bridge.history import MessageHistoryHandler
 from bridge.logger import Logger
 from bridge.openai.handler import OpenAIHandler
-from bridge.utils import telegram_entities_to_markdown
+from bridge.utils import extract_urls, telegram_entities_to_markdown, transform_urls
 from bridge.stats import StatsTracker
 
 config = Config.get_instance()
@@ -223,13 +223,29 @@ class Bridge:
                 server_roles,
             )
 
+            links: List[str] = []
+            message_to_process = message
+            if forwarder.send_as_embed:
+                cleaned_text, links = extract_urls(message)
+                message_to_process = copy.copy(message)
+                message_to_process.message = cleaned_text
+                if message.entities:
+                    message_to_process.entities = [
+                        entity
+                        for entity in message.entities
+                        if not isinstance(entity, MessageEntityUrl)
+                    ]
+
             message_text = await self.process_message_text(
-                message,
+                message_to_process,
                 forwarder.strip_off_links,
                 mention_everyone,
                 mention_roles,
                 config.openai.enabled,
             )
+
+            if forwarder.send_as_embed:
+                links = transform_urls(links)
 
             if message.reply_to and message.reply_to.reply_to_msg_id:
                 discord_reference = (
@@ -244,13 +260,20 @@ class Bridge:
 
             if message.media:
                 sent_discord_messages = await self.handle_message_media(
-                    message, discord_channel, message_text, discord_reference
+                    message,
+                    discord_channel,
+                    message_text,
+                    discord_reference,
+                    forwarder.send_as_embed,
+                    links,
                 )
             else:
                 sent_discord_messages = await self.discord_handler.forward_message(
                     discord_channel,  # type: ignore
                     message_text,
                     reference=discord_reference,
+                    embed=forwarder.send_as_embed,
+                    links=links,
                 )  # type: ignore
 
             if sent_discord_messages:
@@ -496,8 +519,13 @@ class Bridge:
 
         return message_text
 
-    async def process_media_message(
-        self, message: Message, discord_channel, message_text, discord_reference
+    async def process_media_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        message: Message,
+        discord_channel,
+        message_text,
+        discord_reference,
+        send_as_embed: bool,
     ) -> List[DiscordMessage] | None:
         """Process a message that contains media."""
         file_path = await self.telegram_client.download_media(message)
@@ -508,6 +536,7 @@ class Bridge:
                     message_text,
                     image_file=image_file,
                     reference=discord_reference,
+                    embed=send_as_embed,
                 )
                 if not sent_discord_messages:
                     logger.error("Failed to send message to Discord")
@@ -523,34 +552,49 @@ class Bridge:
 
         return sent_discord_messages
 
-    async def handle_message_media(
-        self, message: Message, discord_channel, message_text, discord_reference
+    async def handle_message_media(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        message: Message,
+        discord_channel,
+        message_text,
+        discord_reference,
+        send_as_embed: bool,
+        links: List[str],
     ) -> List[DiscordMessage] | None:
         """Handle a message that contains media."""
-        contains_url = any(
-            isinstance(entity, (MessageEntityTextUrl, MessageEntityUrl))
-            for entity in message.entities or []
-        )
 
         sent_discord_messages: List[DiscordMessage] | None = None
 
-        if contains_url:
+        if links:
             sent_discord_messages = await self.process_url_message(
-                discord_channel, message_text, discord_reference
+                discord_channel, message_text, discord_reference, send_as_embed, links
             )
         else:
             sent_discord_messages = await self.process_media_message(
-                message, discord_channel, message_text, discord_reference
+                message,
+                discord_channel,
+                message_text,
+                discord_reference,
+                send_as_embed,
             )
 
         return sent_discord_messages
 
-    async def process_url_message(
-        self, discord_channel, message_text, discord_reference
+    async def process_url_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        discord_channel,
+        message_text,
+        discord_reference,
+        send_as_embed: bool,
+        links: List[str],
     ) -> List[DiscordMessage]:
         """Process a message that contains a URL."""
         sent_discord_messages = await self.discord_handler.forward_message(
-            discord_channel, message_text, reference=discord_reference
+            discord_channel,
+            message_text,
+            reference=discord_reference,
+            embed=send_as_embed,
+            links=links,
         )
         return sent_discord_messages
 

--- a/bridge/discord/core.py
+++ b/bridge/discord/core.py
@@ -17,6 +17,9 @@ from core import SingletonMeta
 config = Config.get_instance()
 logger = Logger.get_logger(config.application.name)
 
+DISCORD_EMBED_MAX_LENGTH = 4096
+DISCORD_MESSAGE_MAX_LENGTH = 2000
+
 
 class DiscordHandler(metaclass=SingletonMeta):
     """Discord handler class."""
@@ -74,7 +77,10 @@ class DiscordHandler(metaclass=SingletonMeta):
     ) -> List[Message]:
         """Send a message to Discord."""
         sent_messages: List[Message] = []
-        message_parts = split_message(message_text, 4096 if embed else 2000)
+        message_parts = split_message(
+            message_text,
+            DISCORD_EMBED_MAX_LENGTH if embed else DISCORD_MESSAGE_MAX_LENGTH,
+        )
         try:
             if image_file:
                 discord_file = discord.File(image_file)

--- a/bridge/discord/core.py
+++ b/bridge/discord/core.py
@@ -64,27 +64,45 @@ class DiscordHandler(metaclass=SingletonMeta):
         return discord_client
 
     @staticmethod
-    async def forward_message(
+    async def forward_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         discord_channel: TextChannel,
         message_text: str,
         image_file=None,
         reference: MessageReference = ...,
+        embed: bool = False,
+        links: List[str] | None = None,
     ) -> List[Message]:
         """Send a message to Discord."""
-        sent_messages = []
-        message_parts = split_message(message_text)
+        sent_messages: List[Message] = []
+        message_parts = split_message(message_text, 4096 if embed else 2000)
         try:
             if image_file:
                 discord_file = discord.File(image_file)
-                sent_message = await discord_channel.send(
-                    message_parts[0], file=discord_file, reference=reference
-                )
+                if embed:
+                    embed_obj = discord.Embed(description=message_parts[0])
+                    sent_message = await discord_channel.send(
+                        embed=embed_obj, file=discord_file, reference=reference
+                    )
+                else:
+                    sent_message = await discord_channel.send(
+                        message_parts[0], file=discord_file, reference=reference
+                    )
                 sent_messages.append(sent_message)
                 message_parts.pop(0)
 
             for part in message_parts:
-                sent_message = await discord_channel.send(part, reference=reference)
+                if embed:
+                    embed_obj = discord.Embed(description=part)
+                    sent_message = await discord_channel.send(
+                        embed=embed_obj, reference=reference
+                    )
+                else:
+                    sent_message = await discord_channel.send(part, reference=reference)
                 sent_messages.append(sent_message)
+
+            if links:
+                for url in links:
+                    sent_messages.append(await discord_channel.send(url))
         except discord.Forbidden:
             logger.error(
                 "Discord client doesn't have permission to send messages to channel %s",

--- a/bridge/utils.py
+++ b/bridge/utils.py
@@ -184,8 +184,18 @@ def transform_urls(urls: List[str]) -> List[str]:
         parsed = urlparse(url)
         host = parsed.netloc.lower()
         if host in {"x.com", "twitter.com", "www.twitter.com"}:
-            parsed = parsed._replace(netloc="fixupx.com")
-            transformed.append(urlunparse(parsed))
+            transformed.append(
+                urlunparse(
+                    (
+                        parsed.scheme,
+                        "fixupx.com",
+                        parsed.path,
+                        parsed.params,
+                        parsed.query,
+                        parsed.fragment,
+                    )
+                )
+            )
         else:
             transformed.append(url)
     return transformed

--- a/bridge/utils.py
+++ b/bridge/utils.py
@@ -2,6 +2,8 @@
 
 from typing import List, Tuple
 
+from urllib.parse import urlparse, urlunparse
+
 from telethon.tl.types import (
     Message,
     MessageEntityBold,
@@ -10,6 +12,7 @@ from telethon.tl.types import (
     MessageEntityPre,
     MessageEntityStrike,
     MessageEntityTextUrl,
+    MessageEntityUrl,
 )
 
 
@@ -125,3 +128,64 @@ def apply_markdown(
         + text[end:],
         len(opening_delimiter) + len(closing_delimiter),
     )
+
+
+def extract_urls(message: Message) -> Tuple[str, List[str]]:
+    """Extract URLs from a Telegram message.
+
+    Removes plain URLs from the message text and returns the cleaned text
+    along with a list of extracted URLs. Hyperlink entities keep their text
+    intact.
+
+    Args:
+        message: A Telethon Message object.
+
+    Returns:
+        Tuple of cleaned message text and list of URLs.
+    """
+
+    message_text = message.message or ""
+    if not message.entities:
+        return message_text, []
+
+    urls: List[str] = []
+    entities = sorted(message.entities, key=lambda e: e.offset, reverse=True)
+    for entity in entities:
+        if isinstance(entity, MessageEntityTextUrl):
+            if entity.url:
+                urls.append(entity.url)
+        elif isinstance(entity, MessageEntityUrl):
+            url_text = message_text[entity.offset : entity.offset + entity.length]
+            urls.append(url_text)
+            message_text = (
+                message_text[: entity.offset]
+                + message_text[entity.offset + entity.length :]
+            )
+
+    urls.reverse()
+    return message_text.strip(), urls
+
+
+def transform_urls(urls: List[str]) -> List[str]:
+    """Rewrite URLs for better Discord embedding.
+
+    Currently converts Twitter/X links to ``fixupx.com`` so that Discord
+    can render them as embeds.
+
+    Args:
+        urls: List of URLs to transform.
+
+    Returns:
+        List of transformed URLs.
+    """
+
+    transformed = []
+    for url in urls:
+        parsed = urlparse(url)
+        host = parsed.netloc.lower()
+        if host in {"x.com", "twitter.com", "www.twitter.com"}:
+            parsed = parsed._replace(netloc="fixupx.com")
+            transformed.append(urlunparse(parsed))
+        else:
+            transformed.append(url)
+    return transformed

--- a/config-example.yml
+++ b/config-example.yml
@@ -95,6 +95,7 @@ telegram_forwarders:
     tg_channel_id: <tg channel id>
     discord_channel_id: <discord channel id>
     strip_off_links: False # whether to strip off links from the message
+    send_as_embed: False # whether to send messages as Discord embeds
     mention_everyone: True
     forward_everything: False # whether forwarding everything regardless the hashtag
     forward_hashtags:
@@ -106,6 +107,7 @@ telegram_forwarders:
     tg_channel_id: <tg channel id>
     discord_channel_id: <discord channel id>
     strip_off_links: False # whether to strip off links from the message
+    send_as_embed: False # whether to send messages as Discord embeds
     mention_everyone: False
     forward_everything: False # whether forwarding everything regardless the hashtag
     mention_override:

--- a/tests/test_forwarding.py
+++ b/tests/test_forwarding.py
@@ -6,7 +6,10 @@ import asyncio
 import importlib
 from types import SimpleNamespace
 
+from telethon.tl.types import MessageEntityUrl
+
 from bridge.config import config as config_module
+from bridge.utils import extract_urls, transform_urls
 
 from tests.fixtures import write_config
 
@@ -31,3 +34,18 @@ def test_process_message_text(tmp_path, monkeypatch):
 
     assert "@everyone" in result
     assert result.startswith("Admin")
+
+
+def test_extract_urls_and_transform():
+    """URLs are extracted and Twitter links are converted."""
+    url = "https://x.com/test"
+    message = SimpleNamespace(
+        message=f"check {url}",
+        entities=[MessageEntityUrl(offset=6, length=len(url))],
+    )
+
+    cleaned, urls = extract_urls(message)
+    assert cleaned == "check"
+    assert urls == [url]
+
+    assert transform_urls(urls) == ["https://fixupx.com/test"]


### PR DESCRIPTION
## Summary
- allow Telegram channels to send Discord embeds via new `send_as_embed` option
- parse message links and rewrite Twitter/X links to `fixupx.com`
- document embed option and add tests for link extraction

## Testing
- `pre-commit run --files bridge/config/config.py api/routers/config.py bridge/utils.py bridge/core.py bridge/discord/core.py tests/test_forwarding.py config-example.yml README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba9b8153083309ce38f5536fc5d64