### PR TITLE
feat: add AI spam detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A `Python` bridge to forward messages from any Telegram **channel** to your **Di
 - It can run as a daemon and handle any shutdown gracefully, including `SIGTERM` and `SIGINT` signals. It will also save the state of the bridge, so you can resume from where you left off
 - You can enable logging to the file system, which will handle the rotation for you.
 - You can enable the management API to control the bridge remotely, including the ability to log in to Telegram via MFA.
-- You can enable the anti-spam feature to prevent the bridge from forwarding the same message multiple times.
+- You can enable the anti-spam feature to prevent the bridge from forwarding the same message multiple times, or let an AI model flag suspicious messages.
 
 ## Installation
 
@@ -58,6 +58,8 @@ application:
   anti_spam_similarity_timeframe: 60
   # Anti spam similarity threshold (set 0 to 1, with 1 being identical)
   anti_spam_similarity_threshold: 0.8
+  # Anti spam strategy: heuristic or ml (requires OpenAI configuration)
+  anti_spam_strategy: heuristic
 
 # Management API configuration
 api:

--- a/bridge/history/history.py
+++ b/bridge/history/history.py
@@ -12,6 +12,7 @@ from bridge.config import Config
 from bridge.history.contextual_analysis import ContextualAnalysis
 from bridge.history.backends import get_backend
 from bridge.logger import Logger
+from bridge.openai.handler import OpenAIHandler
 
 config = Config.get_instance()
 logger = Logger.get_logger(config.application.name)
@@ -183,7 +184,9 @@ class MessageHistoryHandler:
         )
 
         if config.application.anti_spam_strategy == "ml":
-            logger.debug("ML anti-spam strategy selected but not implemented")
-            return False
+            if not config.openai.enabled:
+                logger.warning("ML anti-spam strategy selected but OpenAI is disabled")
+                return False
+            return await OpenAIHandler().is_spam(telegram_message.text)
 
         return False

--- a/tests/test_spam_filter.py
+++ b/tests/test_spam_filter.py
@@ -1,0 +1,58 @@
+"""Tests for the ML-based spam filter."""
+
+from __future__ import annotations
+
+# pylint: disable=protected-access
+
+import asyncio
+import importlib
+from copy import deepcopy
+from datetime import datetime
+from types import SimpleNamespace
+
+import yaml
+
+from bridge.config import config as config_module
+from tests.fixtures import TEST_CONFIG_DATA
+
+
+class DummyClient:  # pylint: disable=too-few-public-methods
+    """Telegram client stub returning no messages."""
+
+    async def iter_messages(self, *_args, **_kwargs):
+        """Asynchronous generator yielding no messages."""
+        for _ in []:
+            yield _
+
+
+def test_spam_filter_ml(tmp_path, monkeypatch):
+    """When ML strategy is enabled, spam is flagged via OpenAI."""
+
+    cfg = deepcopy(TEST_CONFIG_DATA)
+    cfg["application"]["anti_spam_enabled"] = True
+    cfg["application"]["anti_spam_strategy"] = "ml"
+    cfg["openai"]["enabled"] = True
+    cfg["openai"]["api_key"] = "key"
+    cfg["openai"]["organization"] = "org"
+
+    cfg_file = tmp_path / "config.yml"
+    with cfg_file.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(cfg, handle)
+
+    monkeypatch.setattr(config_module, "_file_path", str(cfg_file))
+    config_module._instances.clear()
+    history_module = importlib.reload(importlib.import_module("bridge.history.history"))
+
+    async def fake_is_spam(self, text):  # pylint: disable=unused-argument
+        return True
+
+    monkeypatch.setattr(history_module.OpenAIHandler, "__init__", lambda self: None)
+    monkeypatch.setattr(history_module.OpenAIHandler, "is_spam", fake_is_spam)
+
+    message = SimpleNamespace(id=1, text="buy now", date=datetime.now())
+
+    handler = history_module.MessageHistoryHandler()
+    result = asyncio.run(
+        handler.spam_filter(telegram_message=message, channel_id=1, tgc=DummyClient())
+    )
+    assert result is True


### PR DESCRIPTION
## Summary
- integrate OpenAI spam classification
- run spam filter through ML strategy when configured
- document AI-powered anti-spam option and add tests

## Testing
- `pre-commit run --files bridge/openai/handler.py bridge/history/history.py README.md tests/test_spam_filter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689defab271883308cc99bf9841a7909