### PR TITLE
feat: enrich messages with fact-check sources

### DIFF
--- a/bridge/config/config.py
+++ b/bridge/config/config.py
@@ -145,6 +145,7 @@ class OpenAIConfig(BaseModel):  # pylint: disable=too-few-public-methods
     api_key: str
     organization: str
     model: str = "gpt-4o-mini"
+    enrich_with_sources: bool = False
     sentiment_analysis_prompt: List[str]
     is_healthy: bool = True  # FIX: This is a hack to make the health check pass
 

--- a/bridge/core.py
+++ b/bridge/core.py
@@ -649,7 +649,7 @@ class Bridge:
                     search = data.get("query", {}).get("search")
                     if search:
                         title = search[0]["title"].replace(" ", "_")
-                        link = f"https://en.wikipedia.org/wiki/{title}"
+                        link = f"https://en.wikipedia.org/wiki/{quote(title)}"
                         results.append((claim, link))
                 except Exception as ex:  # pylint: disable=broad-except
                     logger.error("Error fetching sources for query %s: %s", query, ex)

--- a/bridge/openai/handler.py
+++ b/bridge/openai/handler.py
@@ -60,7 +60,11 @@ class OpenAIHandler(metaclass=SingletonMeta):
             content = response.choices[0].message.content
             if content is None:
                 return []
-            return json.loads(content)
+            try:
+                return json.loads(content)
+            except JSONDecodeError as json_ex:
+                logger.error("Failed to parse OpenAI response as JSON: %s. Content: %r", json_ex, content)
+                return []
         except Exception as ex:  # pylint: disable=broad-except
             logger.error("Error generating fact check suggestions: %s", ex)
             return []

--- a/config-example.yml
+++ b/config-example.yml
@@ -83,6 +83,7 @@ openai:
   api_key: "<your openai api key>"
   organization: "<your openai organization>"
   model: "gpt-4o-mini"
+  enrich_with_sources: False # enable to append fact-check sources
   # The prompt to use for OpenAI, the #text_to_parse will be appended to this prompt
   sentiment_analysis_prompt:
     - "Analyze the following text to determine its sentiment: #text_to_parse.\n\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ Levenshtein==0.27.1
 nltk==3.9.1
 prometheus-client==0.21.0
 aiosqlite==0.20.0
+aiohttp==3.9.5

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+# pylint: disable=import-error,import-outside-toplevel
+
 import yaml
 
 # Central configuration sample reused across tests
@@ -78,3 +80,14 @@ def write_config(tmp_path) -> str:
     with cfg_file.open("w", encoding="utf-8") as handle:
         yaml.safe_dump(TEST_CONFIG_DATA, handle)
     return str(cfg_file)
+
+
+def patch_config(cfg, tmp_path, monkeypatch) -> None:
+    """Write ``cfg`` to ``tmp_path`` and patch the config module."""
+    from bridge.config import config as config_module
+
+    cfg_file = tmp_path / "config.yml"
+    with cfg_file.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(cfg, handle)
+    monkeypatch.setattr(config_module, "_file_path", str(cfg_file))
+    config_module._instances.clear()  # pylint: disable=protected-access

--- a/tests/test_source_enrichment.py
+++ b/tests/test_source_enrichment.py
@@ -1,17 +1,13 @@
 """Tests for message source enrichment."""
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,import-error
 
 import asyncio
 import copy
 import importlib
 from types import SimpleNamespace
 
-import yaml
-
-from bridge.config import config as config_module
-
-from tests.fixtures import TEST_CONFIG_DATA
+from tests.fixtures import TEST_CONFIG_DATA, patch_config
 
 
 def test_enrich_and_send_sources(tmp_path, monkeypatch):
@@ -22,11 +18,7 @@ def test_enrich_and_send_sources(tmp_path, monkeypatch):
     cfg["openai"]["api_key"] = "key"
     cfg["openai"]["organization"] = "org"
     cfg["openai"]["enrich_with_sources"] = True
-    cfg_file = tmp_path / "config.yml"
-    with cfg_file.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(cfg, handle)
-    monkeypatch.setattr(config_module, "_file_path", str(cfg_file))
-    config_module._instances.clear()
+    patch_config(cfg, tmp_path, monkeypatch)
     core = importlib.reload(importlib.import_module("bridge.core"))
 
     async def fake_analyze(_self, _text):

--- a/tests/test_source_enrichment.py
+++ b/tests/test_source_enrichment.py
@@ -1,0 +1,61 @@
+"""Tests for message source enrichment."""
+
+# pylint: disable=protected-access
+
+import asyncio
+import copy
+import importlib
+from types import SimpleNamespace
+
+import yaml
+
+from bridge.config import config as config_module
+
+from tests.fixtures import TEST_CONFIG_DATA
+
+
+def test_enrich_and_send_sources(tmp_path, monkeypatch):
+    """Source links are sent when enrichment is enabled."""
+
+    cfg = copy.deepcopy(TEST_CONFIG_DATA)
+    cfg["openai"]["enabled"] = True
+    cfg["openai"]["api_key"] = "key"
+    cfg["openai"]["organization"] = "org"
+    cfg["openai"]["enrich_with_sources"] = True
+    cfg_file = tmp_path / "config.yml"
+    with cfg_file.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(cfg, handle)
+    monkeypatch.setattr(config_module, "_file_path", str(cfg_file))
+    config_module._instances.clear()
+    core = importlib.reload(importlib.import_module("bridge.core"))
+
+    async def fake_analyze(_self, _text):
+        return [
+            {
+                "claim": "Python created in 1991",
+                "query": "Python programming language 1991",
+            }
+        ]
+
+    async def fake_lookup(_self, _queries):
+        return [("Python created in 1991", "https://example.com/python")]
+
+    captured = {}
+
+    async def fake_forward(_discord_channel, message_text, **_kwargs):
+        captured["text"] = message_text
+        return []
+
+    monkeypatch.setattr(
+        core.OpenAIHandler, "analyze_message_and_generate_suggestions", fake_analyze
+    )
+    monkeypatch.setattr(core.Bridge, "lookup_sources", fake_lookup)
+    monkeypatch.setattr(
+        core.DiscordHandler, "forward_message", staticmethod(fake_forward)
+    )
+
+    bridge = core.Bridge(SimpleNamespace(), SimpleNamespace())
+    channel = SimpleNamespace()
+    asyncio.run(bridge.enrich_and_send_sources("Python is great", channel))
+
+    assert "https://example.com/python" in captured["text"]

--- a/tests/test_spam_filter.py
+++ b/tests/test_spam_filter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,import-error
 
 import asyncio
 import importlib
@@ -10,10 +10,7 @@ from copy import deepcopy
 from datetime import datetime
 from types import SimpleNamespace
 
-import yaml
-
-from bridge.config import config as config_module
-from tests.fixtures import TEST_CONFIG_DATA
+from tests.fixtures import TEST_CONFIG_DATA, patch_config
 
 
 class DummyClient:  # pylint: disable=too-few-public-methods
@@ -35,12 +32,7 @@ def test_spam_filter_ml(tmp_path, monkeypatch):
     cfg["openai"]["api_key"] = "key"
     cfg["openai"]["organization"] = "org"
 
-    cfg_file = tmp_path / "config.yml"
-    with cfg_file.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(cfg, handle)
-
-    monkeypatch.setattr(config_module, "_file_path", str(cfg_file))
-    config_module._instances.clear()
+    patch_config(cfg, tmp_path, monkeypatch)
     history_module = importlib.reload(importlib.import_module("bridge.history.history"))
 
     async def fake_is_spam(self, text):  # pylint: disable=unused-argument


### PR DESCRIPTION
## Summary
- add `openai.enrich_with_sources` flag and example config
- expand OpenAI handler to extract factual claims and search queries
- asynchronously fetch Wikipedia citations and post them after forwarding
- cover source enrichment with tests

## Testing
- `pre-commit run --files requirements.txt bridge/config/config.py config-example.yml bridge/openai/handler.py bridge/core.py tests/test_source_enrichment.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfc62866083309888a5d31b3b301e